### PR TITLE
Use file command instead of file extension.

### DIFF
--- a/lib/clarity/commands/grep_command_builder.rb
+++ b/lib/clarity/commands/grep_command_builder.rb
@@ -30,10 +30,13 @@ class GrepCommandBuilder
 
 
   def exec_functions
-    case File.extname(filename)
-    when '.gz' then gzip_tools
-    when '.bz2' then bzip_tools
-    else default_tools
+    type = `file #{filename}`
+    if type.include?("gzip")
+      gzip_tools
+    elsif type.include?("bzip2")
+      bzip_tools
+    else
+      default_tools
     end
   end
 


### PR DESCRIPTION
We have some odd named gzip files that do not get processed properly. So this is a quick fix to the problem, by not using the file extension to determine the filetype. Has worked perfectly in my testing.

Thanks,
John

---

John Williams
37signals
