### PR TITLE
Add a label to the auto-scroll checkbox

### DIFF
--- a/views/_toolbar.html.erb
+++ b/views/_toolbar.html.erb
@@ -50,7 +50,7 @@
 
     <div id="option-ctrl">
       <ul>
-        <li><input type='checkbox' name='enable_scrolling' id='auto-scroll'/><span> Auto scroll?</span></li>
+        <li><input type='checkbox' name='enable_scrolling' id='auto-scroll'/><label for='auto-scroll'>Auto scroll?</label></li>
       </ul>
     </div>
     


### PR DESCRIPTION
I found the auto-scroll checkbox hard to click. This commit adds a clickable label next to it.
