### PR TITLE
fix auto-scroll

### DIFF
--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -44,7 +44,13 @@ var Search = {
         jQuery.each(['eh', 'em', 'es'], function(){ $('#'+this).val(Search.past_params[this])  });        
       }      
     }
-       
+
+    document.body.onwheel = function(e) {
+      if (e.deltaY < 0) { // disable auto-scroll when scrolling backward
+        $('#auto-scroll').attr('checked', false).change();
+      }
+    };
+
   },
 
   // bind option selectors

--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -95,12 +95,9 @@ var Search = {
 
       //console.log("scroll ON!")
       window._currPos = 0; // init pos
-      this.scroll_fnId = setInterval( function(){
-        if (window._currPos < document.height) {
-          window.scrollTo(0, document.height);
-          window._currPos = document.height;
-        }
-      }, 100 );
+      this.scroll_fnId = setInterval(function() {
+        $('#results')[0].scrollIntoView({ block: "end" });
+      }, 100);
     } else {
       if (!this.scroll_fnId) return; 
       //console.log("scroll off")


### PR DESCRIPTION
A late fix, but I still find clarity useful recently:
1. use `scrollIntoView` to scroll to the bottom.
2. disable auto-scroll when scrolling backward.